### PR TITLE
Simplifying relational db io transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,19 +119,20 @@ with beam.Pipeline(options=PipelineOptions()) as p:
 # {'st': 'Jupiter', 'email': 's@l.no', 'first': 'Star'}
 # {'st': 'Loon', 'email': 'm@s.no', 'first': 'Mark'}
 ```
-* ParseJson
-* AssignUniqueId
-# TODO 
-* Cleanup and DOCs for all transforms
-* WriteToCsv
-* run examples on GCP
-* More examples (write to postgres)
-* unit tests
-* Sql queries support in ReadToRelationalDB
+* Summarize the investigation of using Source/Sink Vs ParDo for IO 
 * Check JdbcIO for inspiration for WriteToRelationalDB/ReadToRelationalDB
-* WriteToRelationalDB, log when db or table is created
-* WriteToRelationalDB, extend the automatic column type inference logic.
+* unit tests
+* All WriteToRelationalDB user to fully configure new Tables
 * WriteToRelationalDB Support specifying primary key(s) when writing to new 
 table
-* Investigate using ParDo instead of Source/Sink for RelationalDB Read/Write (
-as recommended by beam team)
+* Sql queries support in ReadToRelationalDB
+* WriteToRelationalDB, extend the automatic column type inference.
+* more nuggets: WriteToCsv
+* Cleanup and DOCs for all transforms
+* upload to pypi
+* Example how to run on GCP
+* integration tests
+* DB transforms failures handling
+* DB transforms for unbounded sources (e.g. keep sessions alive)
+* more nuggets: Elasticsearch, Mongo 
+* WriteToRelationalDB, logging

--- a/beam_nuggets/io/__init__.py
+++ b/beam_nuggets/io/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import division, print_function
 
 from csv_ import ReadFromCsv
-from relational_db.relational_db_transform import (
-    WriteToRelationalDB,
-    ReadFromRelationalDB
-)
+from relational_db.read_transform import ReadFromRelationalDB
+from relational_db.write_transform import WriteToRelationalDB

--- a/beam_nuggets/io/relational_db/read_transform.py
+++ b/beam_nuggets/io/relational_db/read_transform.py
@@ -1,0 +1,48 @@
+from __future__ import division, print_function
+
+from apache_beam import PTransform, DoFn, ParDo, Create
+
+from .sqlalchemy_db import SqlAlchemyDB
+
+
+class ReadFromRelationalDB(PTransform):
+    def __init__(
+        self,
+        table_name,
+        drivername,
+        host=None,
+        port=None,
+        database=None,
+        username=None,
+        password=None,
+        *args,
+        **kwargs  # TODO check missing *args
+    ):
+        super(ReadFromRelationalDB, self).__init__(*args, **kwargs)
+        self._db_args = dict(
+            host=host,
+            port=port,
+            drivername=drivername,
+            database=database,
+            username=username,
+            password=password,
+            table_name=table_name,
+        )
+
+    def expand(self, pcoll):
+        return (
+            pcoll
+            | Create([self._db_args])
+            | ParDo(_ReadFromRelationalDBFn())
+        )
+
+
+class _ReadFromRelationalDBFn(DoFn):
+    def process(self, element):
+        table_name = element.pop('table_name')
+        db_args = element
+        db = SqlAlchemyDB(**db_args)
+        db.start_session()
+        for record in db.read(table_name):
+            yield record
+        db.close_session()

--- a/beam_nuggets/io/relational_db/write_transform.py
+++ b/beam_nuggets/io/relational_db/write_transform.py
@@ -1,53 +1,9 @@
 from __future__ import division, print_function
 
 from apache_beam import PTransform
-from apache_beam.io.iobase import BoundedSource, Read, Sink, Writer, Write
+from apache_beam.io.iobase import Sink, Writer, Write
 
 from sqlalchemy_db import SqlAlchemyDB
-
-
-class ReadFromRelationalDB(PTransform):
-    def __init__(
-        self,
-        table_name,
-        drivername,
-        host=None,
-        port=None,
-        database=None,
-        username=None,
-        password=None,
-        **kwargs
-    ):
-        super(ReadFromRelationalDB, self).__init__(**kwargs)
-        self._db_args = dict(
-            host=host,
-            port=port,
-            drivername=drivername,
-            database=database,
-            username=username,
-            password=password,
-            table_name=table_name,
-        )
-
-    def expand(self, pcoll):
-        return pcoll | Read(_RelationalDBSource(self._db_args))
-
-
-class _RelationalDBSource(BoundedSource):
-    def __init__(self, db_args):
-        self._table_name = db_args.pop('table_name')
-        self._db_args = db_args
-
-    def read(self, range_tracker):
-        # FIXME handle concurrent read?
-        db = SqlAlchemyDB(**self._db_args)
-        db.start_session()
-        for record in db.read(self._table_name):
-            yield record
-        db.close_session()
-
-    def get_range_tracker(self, start_position, stop_position):
-        pass
 
 
 class WriteToRelationalDB(PTransform):

--- a/examples/read_from_relational_db.py
+++ b/examples/read_from_relational_db.py
@@ -6,9 +6,9 @@ from apache_beam.options.pipeline_options import PipelineOptions
 from beam_nuggets.io import ReadFromRelationalDB
 
 with beam.Pipeline(options=PipelineOptions()) as p:
-    records = p | "Reading records from db" >> ReadFromRelationalDB(
+    months = p | "Reading records from db" >> ReadFromRelationalDB(
         drivername='sqlite',
-        database='/tmp/csv_to_sqlite_dummy.sqlite',
-        table_name='students',
+        database='/tmp/months_db.sqlite',
+        table_name='months',
     )
-    records | 'Writing to stdout' >> beam.Map(print)
+    months | 'Writing to stdout' >> beam.Map(print)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='beam-nuggets',
-    version='0.1.0.dev4',
+    version='0.2.0',
     install_requires=[
         'apache-beam>=2.8.0,<3.0.0',
         'SQLAlchemy>=1.2.14,<2.0.0',


### PR DESCRIPTION
re-implement WriteToRelationalDB and ReadFromRelationalDB using ParDo instead of Sink and Source (as encouraged by the apache beam team https://beam.apache.org/documentation/io/authoring-overview/)