### PR TITLE
Batch improvement

### DIFF
--- a/beam_nuggets/io/relational_db.py
+++ b/beam_nuggets/io/relational_db.py
@@ -170,7 +170,7 @@ class Write(PTransform):
         ))
 
 class _WriteToRelationalDBFn(DoFn):
-    def __init__(self, source_config, table_config, max_batch_size,*args, **kwargs):
+    def __init__(self, source_config, table_config, max_batch_size, *args, **kwargs):
         super(_WriteToRelationalDBFn, self).__init__(*args, **kwargs)
         self.source_config = source_config
         self.table_config = table_config
@@ -207,3 +207,4 @@ class _WriteToRelationalDBFn(DoFn):
     def finish_bundle(self):
         self.commit_records()
         self._db.close_session()
+

--- a/beam_nuggets/io/relational_db.py
+++ b/beam_nuggets/io/relational_db.py
@@ -150,37 +150,60 @@ class Write(PTransform):
                 months = p | "Reading month records" >> beam.Create(records)
                 months | 'Writing to DB table' >> relational_db.Write(
                     source_config=source_config,
-                    table_config=table_config
+                    table_config=table_config,
+                #   max_batch_size=1500  
                 )
 
     """
 
-    def __init__(self, source_config, table_config, *args, **kwargs):
+    def __init__(self, source_config, table_config, max_batch_size=1000, *args, **kwargs):
         super(Write, self).__init__(*args, **kwargs)
         self.source_config = source_config
         self.table_config = table_config
+        self.max_batch_size = max_batch_size
 
     def expand(self, pcoll):
         return pcoll | ParDo(_WriteToRelationalDBFn(
             source_config=self.source_config,
-            table_config=self.table_config
+            table_config=self.table_config,
+            max_batch_size=self.max_batch_size
         ))
 
-
 class _WriteToRelationalDBFn(DoFn):
-    def __init__(self, source_config, table_config, *args, **kwargs):
+    def __init__(self, source_config, table_config, max_batch_size,*args, **kwargs):
         super(_WriteToRelationalDBFn, self).__init__(*args, **kwargs)
         self.source_config = source_config
         self.table_config = table_config
+        self.max_batch_size = max_batch_size
+    
+    def setup(self):
+        self._db = SqlAlchemyDB(self.source_config)
 
     def start_bundle(self):
-        self._db = SqlAlchemyDB(self.source_config)
         self._db.start_session()
+        self.record_counter = 0
+        self.records = []
 
     def process(self, element):
         assert isinstance(element, dict)
+        self.records.append(element)
+        self.record_counter = self.record_counter + 1
         self._db.write_record(self.table_config, element)
 
-    def finish_bundle(self):
-        self._db.close_session()
+        if (self.record_counter > self.max_batch_size):
+            self.commit_records()
+        
+    def commit_records(self):
+        if self.record_counter() == 0:
+            return
 
+        for record in self.records:
+            self._db.write_record(self.table_config, record)
+        
+        self._db.commit_session()
+        self.record_counter = 0
+        self.records = []
+
+    def finish_bundle(self):
+        self.commit_records()
+        self._db.close_session()

--- a/beam_nuggets/io/relational_db_api.py
+++ b/beam_nuggets/io/relational_db_api.py
@@ -261,6 +261,9 @@ class SqlAlchemyDB(object):
         self._session.bind.dispose()
         self._session = None
 
+    def commit_session(self):
+        self._session.commit()
+
     def read(self, table_name):
         table = self._open_table_for_read(table_name)
         for record in table.records(self._session):
@@ -358,7 +361,7 @@ class _Table(object):
                 record=record_dict
             )
             session.execute(insert_stmt)
-            session.commit()
+
         except:
             session.rollback()
             session.close()

--- a/beam_nuggets/io/relational_db_api.py
+++ b/beam_nuggets/io/relational_db_api.py
@@ -361,7 +361,6 @@ class _Table(object):
                 record=record_dict
             )
             session.execute(insert_stmt)
-
         except:
             session.rollback()
             session.close()


### PR DESCRIPTION
The idea is too emulate the way [JDBCIO](https://github.com/apache/beam/blob/a0dbc6f4d87ee3c6144c5afc3d250f98701f771b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java#L1432) writes to SQL.

When calling [`write_record`](https://github.com/mohaseeb/beam-nuggets/blob/39d2493b161ebbcbff9f4857115d527f6fefda77/beam_nuggets/io/relational_db_api.py#L354) it does the `.execute()` and then `.commit()` in sequence, writing and committing each record to disk one at a time. The proposed change allows for more effective batching while better managing connection pooling to CSQL.

- Removed the `session.commit()` from the `write_record` which is called on every element in the `_WriteToRelationalDBFn` ParDo. Instead, we just call `.execute()` on each record, and then commit it to disk all at once.

- Instead of building the engine at the start of each bundle, move `self._db = SqlAlchemyDB(self.source_config)` to the `.setup()` method so it's only created once for the object and handles for connection pooling for the sessions that are opened and closed at the start and finish of each bundle.

- Handled the `.commit()` logic in the DoFn. In the `start_bundle` create a `record_counter = 0` and `records = []`. This will allow us to build the commits up to sizes and ensure that they don't get too big.

- In cases where the bundles are small or divide unevenly leaving a chunk with less than 1000 records, we can directly call `commit_records` in the `finish_bundle()` to take care of the remaining elements in the bundle and flush the buffer.

- Made `max_batch_size` a configurable value with a default value of 1000. This can be changed easily by the user by doing something such as:

```python
relational_db.Write(
    source_config=source_config,
    table_config=table_config
    table_config=table_config,
    max_batch_size=1500
 )
```