### PR TITLE
Fix reading and writing data in different schema from public (Postgres)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,4 @@ scripts/build_test_deploy.sh
 # Licence
 MIT
 
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI](https://img.shields.io/pypi/v/beam-nuggets.svg)](https://pypi.org/project/beam-nuggets/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/beam-nuggets.svg)](https://pypi.org/project/beam-nuggets/)
 
-# About
+# AbouT
 A collection of random transforms for the [Apache beam](https://beam.apache.org/) python SDK . Many are 
 simple transforms. The most useful ones are those for 
 reading/writing from/to relational databases.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI](https://img.shields.io/pypi/v/beam-nuggets.svg)](https://pypi.org/project/beam-nuggets/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/beam-nuggets.svg)](https://pypi.org/project/beam-nuggets/)
 
-# AbouT
+# About
 A collection of random transforms for the [Apache beam](https://beam.apache.org/) python SDK . Many are 
 simple transforms. The most useful ones are those for 
 reading/writing from/to relational databases.
@@ -173,5 +173,3 @@ scripts/build_test_deploy.sh
 
 # Licence
 MIT
-
-

--- a/README.md
+++ b/README.md
@@ -173,3 +173,4 @@ scripts/build_test_deploy.sh
 
 # Licence
 MIT
+

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function
 
 from setuptools import setup, find_packages
 
-VERSION = '0.18.1'
+VERSION = '0.18.2'
 
 REQUIRED_PACKAGES = [
     'apache-beam>=2.8.0,<3.0.0',


### PR DESCRIPTION
This pull request is to fix the issues #27 #46 unable to read and write data in different schema from public(Postgres)

When calling relational_db.ReadFromDB() we can specify the schema which is 'public' by default.
Example:
```
source_config = relational_db.SourceConfiguration(
    drivername='postgresql',
    host='localhost',
    port=5432,
    username='postgres',
    password='postgres',
    database='postgres',
)
relational_db.ReadFromDB(
            source_config=source_config,
            table_name='table_name',
            schema='schema'
        )
```
And when writing to Postgres, we can also specify the schema in  relational_db.TableConfiguration
```
 output_table_config = relational_db.TableConfiguration(
        name='test',
        schema='test_schema',
        create_if_missing=True,
        primary_key_columns=['id']
    )

relational_db.Write(
            source_config=source_config,
            table_config=output_table_config)
```
