### PR TITLE
feat: add support for SQLAlchemy creator argument

### DIFF
--- a/beam_nuggets/io/relational_db_api.py
+++ b/beam_nuggets/io/relational_db_api.py
@@ -103,6 +103,7 @@ class SourceConfiguration(object):
         database=None,
         username=None,
         password=None,
+        creator=None,
         create_if_missing=False,
     ):
         self.url = URL(
@@ -114,6 +115,7 @@ class SourceConfiguration(object):
             database=database
         )
         self.create_if_missing = create_if_missing
+        self.creator = creator
 
 
 class TableConfiguration(object):
@@ -246,7 +248,10 @@ class SqlAlchemyDB(object):
     def __init__(self, source_config):
         self._source = source_config
 
-        self._SessionClass = sessionmaker(bind=create_engine(self._source.url))
+        if self._source.creator:
+            self._SessionClass = sessionmaker(bind=create_engine(self._source.url, creator=self._source.creator))
+        else:
+            self._SessionClass = sessionmaker(bind=create_engine(self._source.url))
         self._session = None  # will be set in self.start_session()
 
         self._name_to_table = {}  # tables metadata cache

--- a/beam_nuggets/io/test/test_base.py
+++ b/beam_nuggets/io/test/test_base.py
@@ -21,10 +21,12 @@ class TransformBaseTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.postgres_source_config = cls.get_postgres_source_config()
+        cls.postgres_creator_source_config = cls.get_postgres_creator_source_config()
         cls.mysql_source_config = cls.get_mysql_source_config()
 
         cls.source_config = (
             cls.postgres_source_config or
+            cls.postgres_creator_source_config or
             cls.mysql_source_config or
             cls.get_sqlite_source_config()
         )
@@ -54,6 +56,26 @@ class TransformBaseTest(unittest.TestCase):
                 database='beam_nuggets_test_db',
                 create_if_missing=True,
             )
+    
+    @classmethod
+    def get_postgres_creator_source_config(cls):
+        cls.postgres_instance = cls.connect_to_postgresql()
+
+        def creator():
+            import pg8000
+            return pg8000.dbapi.connect(
+                host='localhost',
+                port=cls.postgres_instance.settings['port'],
+                user='postgres',
+                database='beam_nuggets_test_db',
+            )
+        if cls.postgres_instance:
+            return SourceConfiguration(
+                drivername='postgresql+pg8000',
+                creator=creator,
+                create_if_missing=True,
+            )
+
 
     @classmethod
     def connect_to_postgresql(cls):


### PR DESCRIPTION
SQLAlchemy's `create_engine` supports a [`creator`](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.creator) argument that allows a callable to be passed that will be called to make the DBAPI connections. 

This is how the [Cloud SQL Python Connector](https://github.com/GoogleCloudPlatform/cloud-sql-python-connector) leverages SQLAlchemy to connect securely to Cloud SQL databases. Supporting the `creator` argument here in beam-nuggets would allow support for the Cloud SQL Python Connector within this library.